### PR TITLE
Use given_name autoComplete for name input box

### DIFF
--- a/client/App/Header/Header.js
+++ b/client/App/Header/Header.js
@@ -62,7 +62,7 @@ const Header = () => {
                                 className={cx('form-input', styles.editNameInput)}
                                 type="text"
                                 placeholder="New name here"
-                                autoComplete="off"
+                                autoComplete="given_name"
                                 autoFocus
                                 maxLength="20"
                                 value={newName}

--- a/client/App/Login/Login.js
+++ b/client/App/Login/Login.js
@@ -73,7 +73,7 @@ const Login = () => {
                         autoFocus
                         type="text"
                         placeholder="Your name here"
-                        autoComplete="off"
+                        autoComplete="given_name"
                         onChange={handleInputChange}
                         maxLength="20"
                     />


### PR DESCRIPTION
I noticed that the name input box would come up with the credit card autocomplete in Chrome. Setting autoComplete to "given_name" will suggest the user's first name instead